### PR TITLE
Upgrade to .NET Aspire 9.1.0

### DIFF
--- a/SupportTicketApi/SupportTicketApi.Api/SupportTicketApi.Api.csproj
+++ b/SupportTicketApi/SupportTicketApi.Api/SupportTicketApi.Api.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.2.0" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/SupportTicketApi/SupportTicketApi.AppHost/Program.cs
+++ b/SupportTicketApi/SupportTicketApi.AppHost/Program.cs
@@ -5,6 +5,7 @@ var sql = builder.AddSqlServer("sql", port: 14329)
                  .AddDatabase("sqldata");
 
 builder.AddProject<Projects.SupportTicketApi_Api>("api")
-    .WithReference(sql);
+    .WithReference(sql)
+    .WaitFor(sql);
 
 builder.Build().Run();

--- a/SupportTicketApi/SupportTicketApi.AppHost/Program.cs
+++ b/SupportTicketApi/SupportTicketApi.AppHost/Program.cs
@@ -1,8 +1,8 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sql = builder.AddSqlServer("sql", port: 14329)
-                 .AddDatabase("sqldata")
-                 .WithEndpoint(port: 14330);
+                 .WithEndpoint(name: "sqlEndpoint", targetPort: 14330)
+                 .AddDatabase("sqldata");
 
 builder.AddProject<Projects.SupportTicketApi_Api>("api")
     .WithReference(sql);

--- a/SupportTicketApi/SupportTicketApi.AppHost/SupportTicketApi.AppHost.csproj
+++ b/SupportTicketApi/SupportTicketApi.AppHost/SupportTicketApi.AppHost.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+	<Sdk Name="Aspire.AppHost.Sdk" Version="9.1.0" />
 	
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/SupportTicketApi/SupportTicketApi.AppHost/SupportTicketApi.AppHost.csproj
+++ b/SupportTicketApi/SupportTicketApi.AppHost/SupportTicketApi.AppHost.csproj
@@ -1,5 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
+	<Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+	
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
@@ -10,11 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Aspire.Hosting" Version="8.2.0" />
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.0" />
+	<PackageReference Include="Aspire.Hosting" Version="9.1.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.1.0" />
 	  
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="8.2.0" />
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.2.0" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="9.1.0" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SupportTicketApi/SupportTicketApi.Data/SupportTicketApi.Data.csproj
+++ b/SupportTicketApi/SupportTicketApi.Data/SupportTicketApi.Data.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.2.0" />
+		<PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.1.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.4" />
 	</ItemGroup>
 

--- a/SupportTicketApi/SupportTicketApi.ServiceDefaults/SupportTicketApi.ServiceDefaults.csproj
+++ b/SupportTicketApi/SupportTicketApi.ServiceDefaults/SupportTicketApi.ServiceDefaults.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>


### PR DESCRIPTION
Updates .NET Aspire to version 9.1.0. 

Continues to target .NET 8.0 LTS and EF Core 8 as @DamianEdwards suggested [here](https://github.com/dotnet/aspire-samples/issues/401)

Updates to the solution branch will be in a separate PR to follow.